### PR TITLE
Log aborting of child process

### DIFF
--- a/bin/hds2graphite-realtime.pl
+++ b/bin/hds2graphite-realtime.pl
@@ -603,7 +603,7 @@ sub initsocket {
         PeerPort => $graphite_port,
         Proto => 'tcp',
         );
-        die "cannot connect to the server $!\n" unless $socket;
+        $log->logdie("cannot connect to the server $!") unless $socket;
         setsockopt($socket, SOL_SOCKET, SO_KEEPALIVE, 1);
         $log->debug("Opening connection ".$socket->sockhost().":".$socket->sockport()." => ".$socket->peerhost().":".$socket->peerport());
 }


### PR DESCRIPTION
The die message itself get not log into log4perl, so you not know why the child died.
You only get a lot of restarting messages.